### PR TITLE
Fix build error (missing includes)

### DIFF
--- a/bluez-include-uio.patch
+++ b/bluez-include-uio.patch
@@ -1,0 +1,21 @@
+--- tools/hciattach_qualcomm.c	2012-06-13 17:04:20.000000000 +0200
++++ tools/hciattach_qualcomm-patched.c	2024-11-12 19:40:29.296161803 +0100
+@@ -27,6 +27,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <sys/uio.h>
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+
+--- tools/hciattach_tialt.c	2012-06-13 17:04:20.000000000 +0200
++++ tools/hciattach_tialt-patched.c	2024-11-12 19:37:58.389273652 +0100
+@@ -26,6 +26,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <sys/uio.h>
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <unistd.h>

--- a/build-custom.sh
+++ b/build-custom.sh
@@ -10,7 +10,9 @@ cd bluez-4.101
 mkdir dist
 DIST=$(pwd)/dist
 cp ../bluez-disable-sdp.patch .
+cp ../bluez-include-uio.patch .
 patch -p0 < bluez-disable-sdp.patch
+patch -p0 < bluez-include-uio.patch
 ./configure --prefix=$DIST --with-systemdunitdir=$DIST/system --disable-service --disable-audio --disable-input --disable-serial
 make && make install
 


### PR DESCRIPTION
The `bluez` version used by the project fails to build unless `sys/uio.h` is included.

Found the fix here: https://github.com/cockpit-project/cockpit/issues/6840#issuecomment-305477356